### PR TITLE
Playing with Postgres

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -179,6 +179,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>42.2.2</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jackson2-provider</artifactId>
             <version>3.0.21.Final</version>

--- a/server/src/main/resources/META-INF/persistence.xml
+++ b/server/src/main/resources/META-INF/persistence.xml
@@ -8,5 +8,9 @@
 
         <non-jta-data-source>jboss/datasources/DataSourcePerspicuus</non-jta-data-source>
 
+        <properties>
+            <property name="hibernate.hbm2ddl.auto" value="update"/>
+        </properties>
+
     </persistence-unit>
 </persistence>

--- a/server/src/main/resources/project-defaults.yml
+++ b/server/src/main/resources/project-defaults.yml
@@ -38,6 +38,10 @@ swarm:
 
   datasources:
     jdbc-drivers:
+      org-postgresql:
+        driver-class-name: org.postgresql.Driver
+        xa-datasource-class-name: org.postgresql.xa.PGXADataSource
+        driver-module-name: org.postgresql
       com-mysql:
         driver-class-name: com.mysql.cj.jdbc.Driver
         xa-datasource-name: com.mysql.jdbc.jdbc2.optional.MysqlXADataSource


### PR DESCRIPTION
Performance team prefers Postgres, instead of MySQL, so I figured adding Postgres driver to allow some runs against a Postgres instance:
```
docker run --name some-postgres -e POSTGRES_PASSWORD=perspicuus -e POSTGRES_USER=perspicuus -e POSTGRES_DATABASE=perspicuus  -d postgres:9.6
```
run the server, like:
```
java -Dswarm.datasources.data-sources.DataSourcePerspicuus.driver-name=org-postgresql -Dswarm.datasources.data-sources.DataSourcePerspicuus.connection-url=jdbc:postgresql://172.17.0.2:5432/perspicuus -Dswarm.datasources.data-sources.DataSourcePerspicuus.user-name=perspicuus -Dswarm.datasources.data-sources.DataSourcePerspicuus.password=perspicuus -jar target/server-0.1.0-SNAPSHOT-swarm
```

and do some test, like:

```
curl -u "testuser:testpass" -X POST -H "Content-Type: application/vnd.schemaregistry.v1+json" --data '{"schema":"{\"type\":\"record\",\"name\":\"recordname\",\"fields\":[{\"name\":\"fieldB\",\"type\":\"string\"},{\"name\":\"fieldsimilarone\",\"type\":\"string\"},{\"name\":\"fieldsimilartwo\",\"type\":\"string\"}]}"}' http://localhost:8080/subjects/testy/versions
```

On the DB, do a ` select * from subjectentity`, and see the added entity in the table;


